### PR TITLE
chore: rename teaching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ingegneria del software orientata ai servizi
+# Architettura software a microservizi
 
-Una raccolta di risorse per l'insegnamento di Ingegneria del software orientata ai servizi del Corso di
-Laurea in Informatica magistrale. Ulteriori informazioni sono disponibili sulla
-[relativa pagina
+Una raccolta di risorse per l'insegnamento di Architetture software a
+microservizi del Corso di Laurea in Informatica magistrale. Ulteriori
+informazioni sono disponibili sulla [relativa pagina
 wiki](https://csunibo.github.io/wiki/raccolte-di-risorse/index.html).


### PR DESCRIPTION
As I renamed the repository itself to respect the new name of this teaching, I also updated the relevant README.

(To rename the repository, I had to delete the old repo with the same name, probably created as an attempt to circumvent the renaming premissions. It was empty anyway.)